### PR TITLE
Fix for ZiTools and MiniMap addon

### DIFF
--- a/Source/ZiTools BetterMiniMap Addon/StaticConstructor.cs
+++ b/Source/ZiTools BetterMiniMap Addon/StaticConstructor.cs
@@ -15,7 +15,9 @@ namespace ZiTools_BetterMiniMap
 	[StaticConstructorOnStartup]
 	public static class StaticConstructor
 	{
-		static StaticConstructor()
+	    public static DesignationOverlay desOv;
+
+        static StaticConstructor()
 		{
 
 			if (ModLister.AllInstalledMods.FirstOrDefault(m => m.Name == "BetterMiniMap")?.Active == true)
@@ -34,7 +36,7 @@ namespace ZiTools_BetterMiniMap
 		{
 			static void Postfix(OverlayManager __instance, Map map)
 			{
-				DesignationOverlay desOv = new DesignationOverlay(map);
+				desOv = new DesignationOverlay(map);
 				__instance.DefOverlays.Add(desOv);
 				ZiTools.ObjectSeeker_Window.UpdateAction += delegate
 				{ desOv.Visible = true; };

--- a/Source/ZiTools/StaticConstructor.cs
+++ b/Source/ZiTools/StaticConstructor.cs
@@ -32,10 +32,7 @@ namespace ZiTools
 		{
 			static void Postfix()
 			{
-			    if (Current.ProgramState != ProgramState.Playing)
-			        OSD_Global.WindowIsOpen = false;
-
-                if (OSD_Global.WindowIsOpen)
+                if (OSD_Global.WindowIsOpen && Current.ProgramState == ProgramState.Playing)
 				{
 					ObjectSeeker_Window.Update();
 				}

--- a/Source/ZiTools/StaticConstructor.cs
+++ b/Source/ZiTools/StaticConstructor.cs
@@ -32,7 +32,10 @@ namespace ZiTools
 		{
 			static void Postfix()
 			{
-				if (OSD_Global.WindowIsOpen)
+			    if (Current.ProgramState != ProgramState.Playing)
+			        OSD_Global.WindowIsOpen = false;
+
+                if (OSD_Global.WindowIsOpen)
 				{
 					ObjectSeeker_Window.Update();
 				}


### PR DESCRIPTION
**1) MiniMap addon**
ZiTools menu can't open anymore after reload savegame or if start new colony

**2) ZiTools**
If ZiTools menu not closed and reload savegame or if start new colony. Game break down and can't create/load map anymore. Need restart game