### PR TITLE
optimize play icon

### DIFF
--- a/Source/ZiTools/StaticConstructor.cs
+++ b/Source/ZiTools/StaticConstructor.cs
@@ -42,15 +42,19 @@ namespace ZiTools
 		[HarmonyPatch(typeof(PlaySettings), "DoPlaySettingsGlobalControls", MethodType.Normal)]
 		class Patch_DoPlaySettingsGlobalControls
 		{
+			static Texture2D icon = ContentFinder<Texture2D>.Get("UI/Lupa(not Pupa)", true);
+			static string tooltip = "ZiT_ObjectsSeekerLabel".Translate();
+			static Type objectSeeker_Window = typeof(ObjectSeeker_Window);
 			static void Postfix(WidgetRow row, bool worldView)
 			{
 				if (!worldView)
 				{
-					bool isSelected = Find.WindowStack.IsOpen(typeof(ObjectSeeker_Window));
-					row.ToggleableIcon(ref isSelected, ContentFinder<Texture2D>.Get("UI/Lupa(not Pupa)", true), "ZiT_ObjectsSeekerLabel".Translate(), SoundDefOf.Mouseover_ButtonToggle);
-					if (isSelected != Find.WindowStack.IsOpen(typeof(ObjectSeeker_Window)))
+					bool isSelected = Find.WindowStack.IsOpen(objectSeeker_Window);
+					row.ToggleableIcon(ref isSelected, icon, tooltip, SoundDefOf.Mouseover_ButtonToggle);
+					bool isSelected2 = Find.WindowStack.IsOpen(objectSeeker_Window);
+					if (isSelected != isSelected2)
 					{
-						if (!Find.WindowStack.IsOpen(typeof(ObjectSeeker_Window)))
+						if (!isSelected2)
 							ObjectSeeker_Window.DrawWindow();
 						else
 							Find.WindowStack.TryRemove(typeof(ObjectSeeker_Window), false);


### PR DESCRIPTION
Optimize suggestion: cache the graphic, otherwise it's fetching from the graphic database every frame. Same with the translation string. This runs around 6x faster.

Not that it's _that big_ of an impact in the first place, but, you know... death by a thousand papercuts.

Sidenote: those 512x512 textures could stand to be 128x128, given how they're used. It's less of a VRAM concern and more of a startup impact.